### PR TITLE
Bad point size fix and set proper file open flags for commands 

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -25,7 +25,8 @@ func main() {
 		os.Stdout = temp
 	}
 
-	db, err := whisper.OpenWithOptions(flag.Args()[0], &whisper.Options{})
+	oflag := os.O_RDONLY
+	db, err := whisper.OpenWithOptions(flag.Args()[0], &whisper.Options{OpenFileFlag: &oflag})
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/icheck.go
+++ b/cmd/icheck.go
@@ -14,7 +14,8 @@ func init() {
 func main() {
 	file1 := os.Args[1]
 
-	db1, err := whisper.OpenWithOptions(file1, &whisper.Options{})
+	oflag := os.O_RDONLY
+	db1, err := whisper.OpenWithOptions(file1, &whisper.Options{OpenFileFlag: &oflag})
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/summarize.go
+++ b/cmd/summarize.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"math"
+	"os"
 	"strings"
 	"time"
 
@@ -32,7 +33,8 @@ func main() {
 	}
 
 	path := flag.Args()[0]
-	db, err := whisper.OpenWithOptions(path, &whisper.Options{})
+	oflag := os.O_RDONLY
+	db, err := whisper.OpenWithOptions(path, &whisper.Options{OpenFileFlag: &oflag})
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -48,12 +48,13 @@ func main() {
 
 	file1 := flag.Args()[0]
 	file2 := flag.Args()[1]
+	oflag := os.O_RDONLY
 
-	db1, err := whisper.OpenWithOptions(file1, &whisper.Options{})
+	db1, err := whisper.OpenWithOptions(file1, &whisper.Options{OpenFileFlag: &oflag})
 	if err != nil {
 		panic(err)
 	}
-	db2, err := whisper.OpenWithOptions(file2, &whisper.Options{})
+	db2, err := whisper.OpenWithOptions(file2, &whisper.Options{OpenFileFlag: &oflag})
 	if err != nil {
 		panic(err)
 	}

--- a/whisper.go
+++ b/whisper.go
@@ -284,6 +284,13 @@ func CreateWithOptions(path string, retentions Retentions, aggregationMethod Agg
 		archive.offset = offset
 
 		if whisper.compressed {
+			if math.IsNaN(float64(archive.avgCompressedPointSize)) || archive.avgCompressedPointSize <= 0 {
+				archive.avgCompressedPointSize = avgCompressedPointSize
+			}
+			if archive.avgCompressedPointSize > MaxCompressedPointSize {
+				archive.avgCompressedPointSize = MaxCompressedPointSize
+			}
+
 			archive.cblock.lastByteBitPos = 7
 			archive.blockSize = int(math.Ceil(float64(whisper.pointsPerBlock)*float64(archive.avgCompressedPointSize))) + endOfBlockSize
 			archive.blockRanges = make([]blockRange, archive.blockCount)

--- a/whisper.go
+++ b/whisper.go
@@ -71,6 +71,7 @@ type Options struct {
 	PointsPerBlock int
 	PointSize      float32
 	InMemory       bool
+	OpenFileFlag   *int
 }
 
 func unitMultiplier(s string) (int, error) {
@@ -388,7 +389,11 @@ func OpenWithOptions(path string, options *Options) (whisper *Whisper, err error
 	if options.InMemory {
 		file = newMemFile(path)
 	} else {
-		file, err = os.OpenFile(path, os.O_RDWR, 0666)
+		flag := os.O_RDWR
+		if options.OpenFileFlag != nil {
+			flag = *options.OpenFileFlag
+		}
+		file, err = os.OpenFile(path, flag, 0666)
 	}
 	if err != nil {
 		return


### PR DESCRIPTION
@azhiltsov noticed a problem in our testing cluster that go-carbon is failing to update some files, which turned out to be a problem in those cwhisper files having NAN point size which in turn make it impossible to save files. This PR would make sure that such point size would illegal and set a proper size for it instead.

learning: 0.0/0.0 = NAN.

Also piggybacking another set of small changes to use proper file flags in some commands.