### PR TITLE
cwhisper: fix old interval trimming bug

### DIFF
--- a/compress.go
+++ b/compress.go
@@ -370,6 +370,7 @@ func (whisper *Whisper) archiveUpdateManyCompressed(archive *archiveInfo, points
 			aindex++
 			baseIntervalsPerUnit[currentUnit] = bpBaseInterval
 
+			// TODO: not efficient if many data points are being written in one call
 			offset := currentUnit*bufferUnitPointsCount + (dp.interval-bpBaseInterval)/archive.secondsPerPoint
 			copy(archive.buffer[offset*PointSize:], dp.Bytes())
 

--- a/compress.go
+++ b/compress.go
@@ -361,6 +361,7 @@ func (whisper *Whisper) archiveUpdateManyCompressed(archive *archiveInfo, points
 		// increasing in time
 		if minInterval != 0 && bpBaseInterval < minInterval {
 			archive.stats.discard.oldInterval++
+			aindex++
 			continue
 		}
 
@@ -434,7 +435,7 @@ func (archive *archiveInfo) getBufferInfo() (units []int, index, min int) {
 			max = v
 			index = i
 		}
-		if min > v {
+		if min == 0 || min > v {
 			min = v
 		}
 	}

--- a/compress.go
+++ b/compress.go
@@ -563,7 +563,7 @@ func (whisper *Whisper) extendIfNeeded() error {
 			if err := whisper.fileReadAt(buf, int64(archive.blockOffset(block.index))); err != nil {
 				return fmt.Errorf("archives[%d].blocks[%d].file.read: %s", i, block.index, err)
 			}
-			dst, _, err := archive.ReadFromBlock(buf, []dataPoint{}, block.start, block.end)
+			dst, _, err := archive.ReadFromBlock(buf, []dataPoint{}, 0, maxInt)
 			if err != nil {
 				return fmt.Errorf("archives[%d].blocks[%d].read: %s", i, block.index, err)
 			}

--- a/debug.go
+++ b/debug.go
@@ -144,11 +144,7 @@ func (archive *archiveInfo) dumpInfoCompressed() {
 
 func (arc *archiveInfo) dumpDataPointsCompressed() {
 	if arc.hasBuffer() {
-		fmt.Printf("archive %s buffer[%d]:\n", arc.Retention, len(arc.buffer)/PointSize)
-		dps := unpackDataPoints(arc.buffer)
-		for i, p := range dps {
-			fmt.Printf("  % 4d %d: %f\n", i, p.interval, p.value)
-		}
+		arc.dumpBuffer()
 	}
 
 	for _, block := range arc.blockRanges {
@@ -181,6 +177,14 @@ func (arc *archiveInfo) dumpDataPointsCompressed() {
 			// continue
 			fmt.Printf("  % 4d %d: %v\n", i, p.interval, p.value)
 		}
+	}
+}
+
+func (arc *archiveInfo) dumpBuffer() {
+	fmt.Printf("archive %s buffer[%d]:\n", arc.Retention, len(arc.buffer)/PointSize)
+	dps := unpackDataPoints(arc.buffer)
+	for i, p := range dps {
+		fmt.Printf("  % 4d %d: %f\n", i, p.interval, p.value)
 	}
 }
 

--- a/debug.go
+++ b/debug.go
@@ -29,7 +29,7 @@ func (whisper *Whisper) CheckIntegrity() {
 			if err := whisper.fileReadAt(buf, int64(arc.blockOffset(block.index))); err != nil {
 				panic(err)
 			}
-			_, _, err := arc.ReadFromBlock(buf, []dataPoint{}, block.start, block.end)
+			_, _, err := arc.ReadFromBlock(buf, []dataPoint{}, 0, maxInt)
 			if err != nil {
 				panic(err)
 			}
@@ -159,7 +159,7 @@ func (arc *archiveInfo) dumpDataPointsCompressed() {
 			panic(err)
 		}
 
-		dps, _, err := arc.ReadFromBlock(buf, []dataPoint{}, block.start, block.end)
+		dps, _, err := arc.ReadFromBlock(buf, []dataPoint{}, 0, maxInt)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
getBufferInfo is always returning min as 0 and this effectively renders the old interval
check (minInterval != 0 && bpBaseInterval < minInterval) in archiveUpdateManyCompressed
useless. 

The impact is old timestamps could be saved, this could caused incorrect read
result. But in theory this should only happen to metrics that is receiving out of order
data points and the gap is larger than the buffer (if a metric is being generated by a
single data source, then it should to be fine).
