### PR TITLE
cmd: refactor verify.go and icheck.go with better name and help message

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -4,8 +4,8 @@
 | --- | --- |
 | convert.go | migrates existing standard whisper files to compressed format |
 | dump.go | prints out data in whipser files (support both compressed and standard format) |
-| verify.go | checks if two whisper files are containing the same data, made for verify migration result |
-| icheck.go | checks if a compressed whipser file is corrupted through crc32 values saved in the headers |
+| compare.go | checks if two whisper files are containing the same data, made for verify migration result |
+| icheck.go | checks if a compressed whipser file is corrupted through crc32 values saved in the headers and if there is invalid data ponit size |
 | summarize.go | generates md5 sums of values in different archives (for quick comparsion of whisper files on different hosts) |
 | estimate.go | to estimate the file compression ratio for specific retention policy on different compressed data point sizes |
 

--- a/cmd/compare.go
+++ b/cmd/compare.go
@@ -24,6 +24,12 @@ func main() {
 	muteThreshold := flag.Int("mute-if-less", 2, "do not alarm if diff of points is less than specified.")
 	flag.BoolVar(verbose, "v", false, "be overly and nicely talkive")
 	flag.Parse()
+	if len(flag.Args()) != 2 {
+		fmt.Println("usage: cverify metric.wsp metric.cwsp")
+		fmt.Println("purpose: check if two whisper files are containing the same data, made for verify migration result.")
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
 
 	var quarantines [][2]int
 	if *quarantinesRaw != "" {
@@ -170,10 +176,16 @@ func main() {
 		}
 	}
 	if db1.IsCompressed() {
-		db1.CheckIntegrity()
+		if err := db1.CheckIntegrity(); err != nil {
+			fmt.Printf("integrity: %s\n%s", file1, err)
+			bad = true
+		}
 	}
 	if db2.IsCompressed() {
-		db2.CheckIntegrity()
+		if err := db2.CheckIntegrity(); err != nil {
+			fmt.Printf("integrity: %s\n%s", file2, err)
+			bad = true
+		}
 	}
 
 	if bad {

--- a/cmd/icheck.go
+++ b/cmd/icheck.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 
@@ -12,6 +13,13 @@ func init() {
 }
 
 func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: icheck metric.wsp")
+		fmt.Println("purpose: checks intergiry of a compressed file, including")
+		fmt.Println("         - crc32 values saved in the headers matched the content")
+		fmt.Println("         - no invalid data ponit size like 0 or NAN")
+		os.Exit(1)
+	}
 	file1 := os.Args[1]
 
 	oflag := os.O_RDONLY
@@ -20,5 +28,8 @@ func main() {
 		panic(err)
 	}
 
-	db1.CheckIntegrity()
+	if err := db1.CheckIntegrity(); err != nil {
+		fmt.Printf("integrity: %s\n%s", file1, err)
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
Also detects bad point size in icheck.go.