### PR TITLE
Fix packSequences for continuous intervals

### DIFF
--- a/whisper.go
+++ b/whisper.go
@@ -986,13 +986,15 @@ func alignPoints(archive *archiveInfo, points []*TimeSeriesPoint) []dataPoint {
 func packSequences(archive *archiveInfo, points []dataPoint) (intervals []int, packedBlocks [][]byte) {
 	intervals = make([]int, 0)
 	packedBlocks = make([][]byte, 0)
+	var prevInterval int
 	for i, point := range points {
-		if i == 0 || point.interval != intervals[len(intervals)-1]+archive.secondsPerPoint {
+		if i == 0 || point.interval != prevInterval+archive.secondsPerPoint {
 			intervals = append(intervals, point.interval)
 			packedBlocks = append(packedBlocks, point.Bytes())
 		} else {
 			packedBlocks[len(packedBlocks)-1] = append(packedBlocks[len(packedBlocks)-1], point.Bytes()...)
 		}
+		prevInterval = point.interval
 	}
 	return
 }

--- a/whisper_test.go
+++ b/whisper_test.go
@@ -818,3 +818,41 @@ func TestOpenValidatation(t *testing.T) {
 
 	testWrite(fullHeader)
 }
+
+func testEqualIntervals(intervals1, intervals2 []int) bool {
+	if len(intervals1) != len(intervals2) {
+		return false
+	}
+	for i, interval1 := range intervals1 {
+		if interval1 != intervals2[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestPackSequences(t *testing.T) {
+	archive := &archiveInfo{
+		Retention: Retention{
+			secondsPerPoint: 1,
+		},
+	}
+	points := []dataPoint{
+		{interval: 1348003785, value: 1},
+		{interval: 1348003786, value: 2},
+		{interval: 1348003787, value: 3},
+		{interval: 1348003789, value: 5},
+		{interval: 1348003790, value: 6},
+		{interval: 1348003792, value: 8},
+	}
+	gotIntervals, _ := packSequences(archive, points)
+	wantIntervals := []int{
+		1348003785,
+		1348003789,
+		1348003792,
+	}
+	if !testEqualIntervals(gotIntervals, wantIntervals) {
+		t.Errorf("intervals unmatch, got=%v, want=%v",
+			gotIntervals, wantIntervals)
+	}
+}


### PR DESCRIPTION
Without this fix, the intervals are split into chunks with two points.
```
$ go test -v -run TestPackSequences
=== RUN   TestPackSequences
    TestPackSequences: whisper_test.go:855: intervals unmatch,
got=[1348003785 1348003787 1348003789 1348003792], want=[1348003785
1348003789 1348003792]
```

With this fix, continuous intervals are packed as one sequence correctly.

FYI: The corresponding Python whisper code: https://github.com/graphite-project/whisper/blob/7f0f533d8bccae5553b7cf3649d57203bc262423/whisper.py#L801-L818